### PR TITLE
Update setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ The `dap-estgi-server` and `dap-estgi-vscode-extension` are application specific
 ## Setup
  - Enable `allow breakpoints everywhere` option in VSCode settings.
 
+### Install Haskell ESTGi Debugger Dependencies
+   - Run `(cd haskell-estgi-debugger ; stack install zip-cmd)`
+
 ### Run `dap-estgi-extension`
    - Run `(cd dap-estgi-vscode-extension ; npm install)`
    - Open `dap-estgi-vscode-extension` folder by using the `Files/Open Folder` menu.
@@ -86,6 +89,8 @@ $ stack run --extra-include-dirs=/usr/local/opt/libomp/include --extra-lib-dirs=
 		   9.2.7:
 			 url: "https://github.com/grin-compiler/foundation-pak/releases/download/ghc-9.2.7/ghc-9.2.7-aarch64-apple-darwin.tar.xz"
 	 ```
+   - If on OSX, install `gmp` in debuggee program
+     i.e. install via brew: `(cd sample-program-to-debug ; brew install gmp)`
    - Run `stack build`
 	 i.e. build the provided sample hello world: `(cd sample-program-to-debug ; stack build)`
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The `dap-estgi-server` and `dap-estgi-vscode-extension` are application specific
 
 ### Install Haskell ESTGi Debugger Dependencies
    - Run `(cd haskell-estgi-debugger ; stack install zip-cmd)`
+   - Ensure `libgmp` is installed (e.g. if using homebrew, `brew install gmp`)
 
 ### Run `dap-estgi-extension`
    - Run `(cd dap-estgi-vscode-extension ; npm install)`
@@ -89,8 +90,6 @@ $ stack run --extra-include-dirs=/usr/local/opt/libomp/include --extra-lib-dirs=
 		   9.2.7:
 			 url: "https://github.com/grin-compiler/foundation-pak/releases/download/ghc-9.2.7/ghc-9.2.7-aarch64-apple-darwin.tar.xz"
 	 ```
-   - If on OSX, install `gmp` in debuggee program
-     i.e. install via brew: `(cd sample-program-to-debug ; brew install gmp)`
    - Run `stack build`
 	 i.e. build the provided sample hello world: `(cd sample-program-to-debug ; stack build)`
 


### PR DESCRIPTION
When going through the setup instructions on a x86 darwin, I ran into two issues:

1. Needing to `brew install gmp` 
<img width="1708" alt="Screenshot 2023-07-31 at 12 00 01 PM" src="https://github.com/haskell-debugger/haskell-estgi-debugger/assets/10222826/21f25d52-fa0d-458c-b6a6-12880343d478">

2. Needing to `stack install zip-cmd`
<img width="1696" alt="Screenshot 2023-07-31 at 12 00 43 PM" src="https://github.com/haskell-debugger/haskell-estgi-debugger/assets/10222826/e61888b4-228a-4afa-9ab5-5eb8bce23a7d">

After adding the above two dependencies, I was able to get the debugger running! :) Super exciting!! 

